### PR TITLE
Switch to vanilla libsecp256k1

### DIFF
--- a/build-libwally.sh
+++ b/build-libwally.sh
@@ -35,6 +35,15 @@ fi
 
 cd CLibWally/libwally-core
 
+# Switch to vanilla libsecp256k1, rather than the more experimental libsecp256k1-zkp.
+# Since libsecp256k1-zkp is rebased on vanilla libsecp256k1, we can simply checkout
+# a common commit.
+pushd src/secp256k1
+  # Latest commit used in Bitcoin Core:
+  # https://github.com/bitcoin/bitcoin/commits/master/src/secp256k1
+  git checkout 8746600eec5e7fcd35dabd480839a3a4bdfee87b || exit 1
+popd
+
 if [ $clean == 1 ]; then
   rm -rf build
 fi
@@ -61,7 +70,7 @@ if [ $simulator == 1 ]; then
       arch_target="aarch64-apple-darwin"
     fi
 
-    ./configure --disable-shared --host=$arch_target --enable-static --disable-elements
+    ./configure --disable-shared --host=$arch_target --enable-static --disable-elements --enable-standard-secp
 
     if [ $clean == 1 ]; then
       set -v # display commands
@@ -82,7 +91,7 @@ if [ $device == 1 ]; then
     export CFLAGS="-O3 -arch arm64 -arch arm64e -arch armv7 -arch armv7s -fembed-bitcode -mios-version-min=10.0 -isysroot `xcrun -sdk iphoneos --show-sdk-path`"
     export CXXFLAGS="-O3 -arch arm64 -arch arm64e -arch armv7 -arch armv7s -isysroot -fembed-bitcode -mios-version-min=10.0 -isysroot `xcrun -sdk iphoneos --show-sdk-path`"
     mkdir -p build
-    ./configure --disable-shared --host=aarch64-apple-darwin14 --enable-static --disable-elements
+    ./configure --disable-shared --host=aarch64-apple-darwin14 --enable-static --disable-elements --enable-standard-secp
     if [ $clean == 1 ]; then
       make clean
     fi


### PR DESCRIPTION
Libwally includes libsecp256k1-zkp as a submodule, because it has support for cryptographic functions used in Elements.

This PR swaps out the submodule with vanilla libsecp256k1 which is used by Bitcoin Core. It also uses the same version.

- [x] Depends on https://github.com/ElementsProject/libwally-core/pull/301 and a new release.