### PR TITLE
[wip] Cleanup build script, use XCFramework

### DIFF
--- a/LibWally.podspec
+++ b/LibWally.podspec
@@ -17,12 +17,12 @@ Pod::Spec.new do |spec|
   spec.platform     = :ios, "10"
   spec.swift_version = '5.0'
 
-  spec.source       = { :git => "https://github.com/Sjors/libwally-swift.git", :tag => "v#{spec.version}", :submodules => true  }
+  spec.source       = { :git => "https://github.com/jurvis/libwally-swift.git", :tag => "v#{spec.version}", :submodules => true  }
 
   spec.vendored_frameworks = "build/LibwallySwift.xcframework"
 
   spec.preserve_paths = "build/LibwallySwift.xcframework"
-
+  spec.pod_target_xcconfig = { 'ONLY_ACTIVE_ARCH' => 'YES' }
   spec.prepare_command = './build-libwally.sh -sdc'
   spec.cocoapods_version = '>= 1.10.0'
 end

--- a/LibWally.podspec
+++ b/LibWally.podspec
@@ -6,7 +6,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "LibWally"
-  spec.version      = "0.0.1"
+  spec.version      = "0.0.7"
   spec.summary      = "Swift wrapper for LibWally."
   spec.description  = "Swift wrapper for LibWally, a collection of useful primitives for cryptocurrency wallets."
   spec.homepage     = "https://github.com/Sjors/libwally-swift"
@@ -19,19 +19,10 @@ Pod::Spec.new do |spec|
 
   spec.source       = { :git => "https://github.com/Sjors/libwally-swift.git", :tag => "v#{spec.version}", :submodules => true  }
 
-  spec.source_files = "LibWally"
-
   spec.vendored_frameworks = "build/LibwallySwift.xcframework"
 
-  spec.pod_target_xcconfig = {
-                               'SWIFT_INCLUDE_PATHS' => '$(PODS_TARGET_SRCROOT)/CLibWally',
-                               'LIBRARY_SEARCH_PATHS' => '$(PODS_TARGET_SRCROOT)/CLibWally/libwally-core/src/.libs'
-                             }
-
-  spec.preserve_paths = 'LibWally/LibWally.modulemap', 'CLibWally', "build/LibwallySwift.xcframework"
-
-  spec.module_map = 'LibWally/LibWally.modulemap'
+  spec.preserve_paths = "build/LibwallySwift.xcframework"
 
   spec.prepare_command = './build-libwally.sh -sdc'
-
+  spec.cocoapods_version = '>= 1.10.0'
 end

--- a/LibWally.podspec
+++ b/LibWally.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |spec|
                                'LIBRARY_SEARCH_PATHS' => '$(PODS_TARGET_SRCROOT)/CLibWally/libwally-core/src/.libs'
                              }
 
-  spec.preserve_paths = 'LibWally/LibWally.modulemap', 'CLibWally'
+  spec.preserve_paths = 'LibWally/LibWally.modulemap', 'CLibWally', "build/LibwallySwift.xcframework"
 
   spec.module_map = 'LibWally/LibWally.modulemap'
 

--- a/LibWally.podspec
+++ b/LibWally.podspec
@@ -24,10 +24,10 @@ Pod::Spec.new do |spec|
   spec.vendored_frameworks = "build/LibwallySwift.xcframework"
 
   spec.pod_target_xcconfig = {
-                               'SWIFT_WHOLE_MODULE_OPTIMIZATION' => 'YES',
                                'SWIFT_INCLUDE_PATHS' => '$(PODS_TARGET_SRCROOT)/CLibWally',
                                'LIBRARY_SEARCH_PATHS' => '$(PODS_TARGET_SRCROOT)/CLibWally/libwally-core/src/.libs'
                              }
+
   spec.preserve_paths = 'LibWally/LibWally.modulemap', 'CLibWally'
 
   spec.module_map = 'LibWally/LibWally.modulemap'

--- a/LibWally.podspec
+++ b/LibWally.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |spec|
 
   spec.source_files = "LibWally"
 
-  spec.vendored_libraries = "CLibWally/libwally-core/src/.libs/libwallycore.a"
+  spec.vendored_frameworks = "build/LibwallySwift.xcframework"
 
   spec.pod_target_xcconfig = {
                                'SWIFT_WHOLE_MODULE_OPTIMIZATION' => 'YES',

--- a/LibWally.xcodeproj/project.pbxproj
+++ b/LibWally.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		759B2C4D2801473C00606FC8 /* libsecp256k1.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 759B2C4C2801472D00606FC8 /* libsecp256k1.a */; };
 		A20C942522C6BC3900B0D206 /* libwallycore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A20C942422C6BC3900B0D206 /* libwallycore.a */; };
 		A232260122B94A6B00C3B79C /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = A232260022B94A6B00C3B79C /* Transaction.swift */; };
 		A232260322B94A8400C3B79C /* TransactionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A232260222B94A8400C3B79C /* TransactionTests.swift */; };
@@ -37,6 +38,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		759B2C4C2801472D00606FC8 /* libsecp256k1.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libsecp256k1.a; path = "CLibWally/libwally-core/src/secp256k1/.libs/libsecp256k1.a"; sourceTree = "<group>"; };
 		A20557A522C6CDBE007221AA /* LibWally.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = LibWally.modulemap; sourceTree = "<group>"; };
 		A20C942422C6BC3900B0D206 /* libwallycore.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libwallycore.a; path = "CLibWally/libwally-core/src/.libs/libwallycore.a"; sourceTree = "<group>"; };
 		A20C942622C6BDB000B0D206 /* CLibWally */ = {isa = PBXFileReference; lastKnownFileType = folder; path = CLibWally; sourceTree = "<group>"; };
@@ -67,6 +69,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				759B2C4D2801473C00606FC8 /* libsecp256k1.a in Frameworks */,
 				A20C942522C6BC3900B0D206 /* libwallycore.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -138,6 +141,7 @@
 		FEB0B466229C6B6C00459518 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				759B2C4C2801472D00606FC8 /* libsecp256k1.a */,
 				A20C942422C6BC3900B0D206 /* libwallycore.a */,
 			);
 			name = Frameworks;
@@ -438,6 +442,7 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/CLibWally/libwally-core/src/.libs",
+					"$(PROJECT_DIR)/CLibWally/libwally-core/src/secp256k1/.libs",
 				);
 				MARKETING_VERSION = 0.0.6;
 				MODULEMAP_FILE = "$(SRCROOT)/LibWally/LibWally.modulemap";
@@ -475,6 +480,7 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/CLibWally/libwally-core/src/.libs",
+					"$(PROJECT_DIR)/CLibWally/libwally-core/src/secp256k1/.libs",
 				);
 				MARKETING_VERSION = 0.0.6;
 				MODULEMAP_FILE = "$(SRCROOT)/LibWally/LibWally.modulemap";

--- a/LibWally/Address.swift
+++ b/LibWally/Address.swift
@@ -11,7 +11,7 @@
 let WALLY_ADDRESS_TYPE_P2TR: Int32 = 0x08 // P2TR taproot address ("bc1p..)"
 
 import Foundation
-import CLibWally
+@_implementationOnly import CLibWally
 
 public enum AddressType {
     case payToPubKeyHash // P2PKH (legacy)

--- a/LibWally/BIP32.swift
+++ b/LibWally/BIP32.swift
@@ -7,7 +7,7 @@
 //  license, see the accompanying file LICENSE.md
 
 import Foundation
-import CLibWally
+@_implementationOnly import CLibWally
 
 public enum Network : Equatable {
     case mainnet

--- a/LibWally/BIP39.swift
+++ b/LibWally/BIP39.swift
@@ -8,7 +8,7 @@
 //
 
 import Foundation
-import CLibWally
+@_implementationOnly import CLibWally
 
 let MAX_BYTES = 32 // Arbitrary, used only to determine array size in bip39_mnemonic_to_bytes
 

--- a/LibWally/DataExtension.swift
+++ b/LibWally/DataExtension.swift
@@ -7,7 +7,7 @@
 //  license, see the accompanying file LICENSE.md
 
 import Foundation
-import CLibWally
+@_implementationOnly import CLibWally
 
 public extension Data {
 

--- a/LibWally/PSBT.swift
+++ b/LibWally/PSBT.swift
@@ -7,7 +7,7 @@
 //  license, see the accompanying file LICENSE.md
 
 import Foundation
-import CLibWally
+@_implementationOnly import CLibWally
 
 public struct KeyOrigin : Equatable {
     let fingerprint: Data

--- a/LibWally/Script.swift
+++ b/LibWally/Script.swift
@@ -8,7 +8,7 @@
 //  Distributed under the MIT software license, see the accompanying file LICENSE.md
 
 import Foundation
-import CLibWally
+@_implementationOnly import CLibWally
 
 let a = WALLY_SCRIPT_TYPE_OP_RETURN
 

--- a/LibWally/Transaction.swift
+++ b/LibWally/Transaction.swift
@@ -7,7 +7,7 @@
 //  license, see the accompanying file LICENSE.md
 
 import Foundation
-import CLibWally
+@_implementationOnly import CLibWally
 
 public typealias Satoshi = UInt64
 
@@ -45,7 +45,7 @@ public struct TxOutput {
         self.wally_tx_output = output!.pointee
     }
     
-    public init (tx_output: wally_tx_output, scriptPubKey: ScriptPubKey, network: Network) {
+    internal init (tx_output: wally_tx_output, scriptPubKey: ScriptPubKey, network: Network) {
         self.network = network
         self.wally_tx_output = tx_output
         self.scriptPubKey = scriptPubKey

--- a/build-libwally.sh
+++ b/build-libwally.sh
@@ -67,7 +67,7 @@ if [ $simulator == 1 ]; then
   fi
   make
   cd $PROJ_DIRECTORY
-  xcodebuild archive -scheme LibWally -destination "generic/platform=iOS Simulator" -archivePath ${BIN_OUTPUT_DIRECTORY}/LibwallySwift-Sim
+  xcodebuild archive -scheme LibWally -destination "generic/platform=iOS Simulator" -archivePath ${BIN_OUTPUT_DIRECTORY}/LibwallySwift-Sim ONLY_ACTIVE_ARCH=NO SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES
   if [ $device != 1 ]; then
     xcodebuild -create-xcframework \
       -framework ${BIN_OUTPUT_DIRECTORY}/LibwallySwift-Sim.xcarchive/Products/Library/Frameworks/LibWally.framework \
@@ -105,6 +105,8 @@ set +v
 if [ $device == 1 ] && [ $simulator == 1 ]; then
   echo "Combine simulator and device libraries..."
   set -v
+
+  rm -rf ${BIN_OUTPUT_DIRECTORY}/LibwallySwift.xcframework
 
   xcodebuild -create-xcframework \
     -framework ${BIN_OUTPUT_DIRECTORY}/LibwallySwift-iOS.xcarchive/Products/Library/Frameworks/LibWally.framework \

--- a/build-libwally.sh
+++ b/build-libwally.sh
@@ -67,7 +67,7 @@ if [ $simulator == 1 ]; then
   fi
   make
   cd $PROJ_DIRECTORY
-  xcodebuild archive -scheme LibWally -destination "generic/platform=iOS Simulator" -archivePath ${BIN_OUTPUT_DIRECTORY}/LibwallySwift-Sim CLANG_ADDRESS_SANITIZER=NO CLANG_ADDRESS_SANITIZER_ALLOW_ERROR_RECOVERY=NO CLANG_ADDRESS_SANITIZER_USE_AFTER_SCOPE=NO SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+  xcodebuild archive -scheme LibWally -destination "generic/platform=iOS Simulator" -archivePath ${BIN_OUTPUT_DIRECTORY}/LibwallySwift-Sim
   if [ $device != 1 ]; then
     xcodebuild -create-xcframework \
       -framework ${BIN_OUTPUT_DIRECTORY}/LibwallySwift-Sim.xcarchive/Products/Library/Frameworks/LibWally.framework \
@@ -92,7 +92,7 @@ if [ $device == 1 ]; then
   make
   set +v
   cd $PROJ_DIRECTORY
-  xcodebuild archive -scheme LibWally -destination "generic/platform=iOS" -archivePath ${BIN_OUTPUT_DIRECTORY}/LibwallySwift-iOS ENABLE_BITCODE=NO CLANG_ADDRESS_SANITIZER=NO CLANG_ADDRESS_SANITIZER_ALLOW_ERROR_RECOVERY=NO CLANG_ADDRESS_SANITIZER_USE_AFTER_SCOPE=NO SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+  xcodebuild archive -scheme LibWally -destination "generic/platform=iOS" -archivePath ${BIN_OUTPUT_DIRECTORY}/LibwallySwift-iOS SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES
   if [ $simulator != 1 ]; then
     set -v
     xcodebuild -create-xcframework \

--- a/build-libwally.sh
+++ b/build-libwally.sh
@@ -50,8 +50,8 @@ if [ $simulator == 1 ]; then
   if [ ! -d "build" ]; then
     echo "Configure and compile for the simulator..."
     set -v
-    export CFLAGS="-O3 -arch x86_64 -arch i386 -fembed-bitcode-marker -mios-simulator-version-min=10.0 -isysroot `xcrun -sdk iphonesimulator --show-sdk-path`"
-    export CXXFLAGS="-O3 -arch x86_64 -arch i386 -fembed-bitcode-marker -mios-simulator-version-min=10.0 -isysroot `xcrun -sdk iphonesimulator --show-sdk-path`"
+    export CFLAGS="-O3 -arch arm64 -arch x86_64 -fembed-bitcode-marker -mios-simulator-version-min=11.0 -isysroot `xcrun -sdk iphonesimulator --show-sdk-path`"
+    export CXXFLAGS="-O3 -arch arm64 -arch x86_64 -fembed-bitcode-marker -mios-simulator-version-min=11.0 -isysroot `xcrun -sdk iphonesimulator --show-sdk-path`"
     mkdir -p build
 
     ./configure --disable-shared --host=aarch64-apple-darwin --enable-static --disable-elements
@@ -72,8 +72,8 @@ if [ $device == 1 ]; then
   if [ ! -d "build" ] || [ $clean == 1 ]; then
     echo "Configure and cross-compile for the device..."
     set -v
-    export CFLAGS="-O3 -arch arm64 -arch arm64e -arch armv7 -arch armv7s -fembed-bitcode -mios-version-min=10.0 -isysroot `xcrun -sdk iphoneos --show-sdk-path`"
-    export CXXFLAGS="-O3 -arch arm64 -arch arm64e -arch armv7 -arch armv7s -isysroot -fembed-bitcode -mios-version-min=10.0 -isysroot `xcrun -sdk iphoneos --show-sdk-path`"
+    export CFLAGS="-O3 -arch arm64 -fembed-bitcode -mios-version-min=11.0 -isysroot `xcrun -sdk iphoneos --show-sdk-path`"
+    export CXXFLAGS="-O3 -arch arm64 -fembed-bitcode -mios-version-min=11.0 -isysroot `xcrun -sdk iphoneos --show-sdk-path`"
     mkdir -p build
     ./configure --disable-shared --host=aarch64-apple-darwin --enable-static --disable-elements
     if [ $clean == 1 ]; then

--- a/build-libwally.sh
+++ b/build-libwally.sh
@@ -54,14 +54,7 @@ if [ $simulator == 1 ]; then
     export CXXFLAGS="-O3 -arch x86_64 -arch i386 -fembed-bitcode-marker -mios-simulator-version-min=10.0 -isysroot `xcrun -sdk iphonesimulator --show-sdk-path`"
     mkdir -p build
 
-    architecture=$(uname -m)
-    arch_target="x86_64-apple-darwin"
-
-    if [ "$architecture" = "arm64" ]; then
-      arch_target="aarch64-apple-darwin"
-    fi
-
-    ./configure --disable-shared --host=$arch_target --enable-static --disable-elements
+    ./configure --disable-shared --host=aarch64-apple-darwin --enable-static --disable-elements
 
     if [ $clean == 1 ]; then
       set -v # display commands
@@ -82,7 +75,7 @@ if [ $device == 1 ]; then
     export CFLAGS="-O3 -arch arm64 -arch arm64e -arch armv7 -arch armv7s -fembed-bitcode -mios-version-min=10.0 -isysroot `xcrun -sdk iphoneos --show-sdk-path`"
     export CXXFLAGS="-O3 -arch arm64 -arch arm64e -arch armv7 -arch armv7s -isysroot -fembed-bitcode -mios-version-min=10.0 -isysroot `xcrun -sdk iphoneos --show-sdk-path`"
     mkdir -p build
-    ./configure --disable-shared --host=aarch64-apple-darwin14 --enable-static --disable-elements
+    ./configure --disable-shared --host=aarch64-apple-darwin --enable-static --disable-elements
     if [ $clean == 1 ]; then
       make clean
     fi


### PR DESCRIPTION
**This PR is still a work in progress!**
fixes https://github.com/Sjors/libwally-swift/issues/59
## Purpose
This PR primarily does a few things:
1. Support latest `libtool@2.4.7` change which will require a PR merge in `libwally-core` (https://github.com/ElementsProject/libwally-core/pull/321)2. 
2. Support running in iOS simulator on M1 Macs

## Implementation
To achieve 1, I noticed that the latest `libwally-core` change no longer includes `libsecp256k1` symbols inside the `libwally-core.a` library. To keep this simple, I imported `libsecp256k1.a` from `CLibWally/libwally-core/src/secp256k1/.libs` to the Xcode project

To achieve 2, we will have to build an `xcodebuild -xcframework` instead of using the previous `lipo` build command. This is because M1 macs use `arm64` as an architecture for iOS simulator, which will conflict in a fat binary since an iOS simulator's `arm64` arch is undifferentiated from an iOS device's `arm64` arch.


## Testing Notes
- [ ] Cocoapods Install
- [ ] Carthage script update (?)

## Follow-up
- Add Swift Package Manager support (?)
- Now that we use xcframeworks, we can probably support Mac Catalyst too (https://github.com/Sjors/libwally-swift/issues/41)