### PR TITLE
Use libwally's BIP32 path parsing for derivations

### DIFF
--- a/DemoPlayground.playground/Contents.swift
+++ b/DemoPlayground.playground/Contents.swift
@@ -21,7 +21,7 @@ let masterKey = HDKey(seedHex, .mainnet)!
 masterKey.description
 // Wallets are often identified by their master fingerprint
 masterKey.fingerprint.hexString
-let path = BIP32Path("m/44'/0'/0'")!
+let path = "m/44'/0'/0'"
 var account = try! masterKey.derive(path)
 account.xpub
 account.address(.payToWitnessPubKeyHash)
@@ -34,10 +34,10 @@ address?.scriptPubKey.type
 //
 // Destination address. We only need public keys for this, so start by parsing a tpub (xpub for testnet):
 account = HDKey("tpubDDgEAMpHn8tX5Bs19WWJLZBeFzbpE7BYuP3Qo71abZnQ7FmN3idRPg4oPWt2Q6Uf9huGv7AGMTu8M2BaCxAdThQArjLWLDLpxVX2gYfh2YJ")!
-let destinationAddress = try! account.derive(BIP32Path("0/5")!).address(.payToWitnessPubKeyHash)
+let destinationAddress = try! account.derive("0/5").address(.payToWitnessPubKeyHash)
 
 // Legacy input:
-let key1 = try! account.derive(BIP32Path("0/0")!)
+let key1 = try! account.derive("0/0")
 let address1 = key1.address(.payToPubKeyHash)
 let amount: Satoshi = 10000000 // 0.1 BTC
 // This has been funded with 0.1 tBTC in transaction 48bf2039d28b369080400e3d6a16be49d09ffd9edbd794686b30234e2c4dd0b5, output 0
@@ -66,7 +66,7 @@ transaction.feeRate // Satoshi per byte
 // In order to sign it we need the private keys (in the same order as [TxInput]):
 let accountPriv = HDKey("tprv8gzC1wn3dmCrBiqDFrqhw9XXgy5t4mzeL5SdWayHBHz1GmWbRKoqDBSwDLfunPAWxMqZ9bdGsdpTiYUfYiWypv4Wfj9g7AYX5K3H9gRYNCA")!
 account.xpub == accountPriv.xpub
-let privKey1 = try! accountPriv.derive(BIP32Path("0/0")!)
+let privKey1 = try! accountPriv.derive("0/0")
 transaction.sign([privKey1])
 transaction.description
 
@@ -79,7 +79,7 @@ transaction.vbytes // 188
 // When spending native SegWit, construct the input as follows:
 
 // Native SegWit input:
-let key2 = try! account.derive(BIP32Path("0/1")!)
+let key2 = try! account.derive("0/1")
 let address2 = key2.address(.payToWitnessPubKeyHash) // tb1q5h88ajzdl5czjuc57lfjlnwepprlgd9sj2fqkx
 // This has been funded with 0.1 tBTC in transaction 400b52dab0a2bb5ce5fdf5405a965394b43a171828cd65d35ffe1eaa0a79a5c4, output 1
 let txId2 = "400b52dab0a2bb5ce5fdf5405a965394b43a171828cd65d35ffe1eaa0a79a5c4"
@@ -104,7 +104,7 @@ transaction.vbytes // 110
 transaction.fee // Satoshi
 transaction.feeRate // Satoshi per byte
 
-let privKey2 = try! accountPriv.derive(BIP32Path("0/1")!)
+let privKey2 = try! accountPriv.derive("0/1")
 transaction.sign([privKey2])
 transaction.description
 
@@ -112,7 +112,7 @@ transaction.description
 transaction.vbytes // 110
 
 // When spending wrapped SegWit, construct the input as follows:
-let key3 = try! account.derive(BIP32Path("0/2")!)
+let key3 = try! account.derive("0/2")
 let address3 = key3.address(.payToScriptHashPayToWitnessPubKeyHash) // 2N8JzYHt1L2FJkBt37geLatfW6DBXCZW9pr
 // This has been funded with 0.1 tBTC in transaction 5f50a17eb6eab5437b79f357f37a5198a21d9d8dd226b66d8189f3a2fc66dce4, output 0
 let txId3 = "5f50a17eb6eab5437b79f357f37a5198a21d9d8dd226b66d8189f3a2fc66dce4"
@@ -136,7 +136,7 @@ transaction.vbytes // 133
 transaction.fee // Satoshi
 transaction.feeRate // Satoshi per byte
 
-let privKey3 = try! accountPriv.derive(BIP32Path("0/2")!)
+let privKey3 = try! accountPriv.derive("0/2")
 transaction.sign([privKey3])
 transaction.description
 

--- a/LibWallyTests/BIP32Tests.swift
+++ b/LibWallyTests/BIP32Tests.swift
@@ -91,7 +91,7 @@ class BIP32Tests: XCTestCase {
         let hdKey = HDKey(seed)!
         XCTAssertEqual(hdKey.masterKeyFingerprint?.hexString, "b4e3f5ed")
 
-        let childKey = try! HDKey(seed)!.derive(BIP32Path(0))
+        let childKey = try! HDKey(seed)!.derive("0")
         XCTAssertEqual(childKey.masterKeyFingerprint?.hexString, "b4e3f5ed")
         
         let tpub = "tpubDDgEAMpHn8tX5Bs19WWJLZBeFzbpE7BYuP3Qo71abZnQ7FmN3idRPg4oPWt2Q6Uf9huGv7AGMTu8M2BaCxAdThQArjLWLDLpxVX2gYfh2YJ"
@@ -105,48 +105,11 @@ class BIP32Tests: XCTestCase {
         XCTAssertEqual(key.masterKeyFingerprint?.hexString, "d90c6a4f")
     }
     
-    func testRelativePathFromString() {
-        let path = BIP32Path("0'/0")
-        XCTAssertNotNil(path)
-        XCTAssertEqual(path!.components, [.hardened(0), .normal(0)])
-        XCTAssertEqual(path!.description, "0h/0")
-    }
-    
-    func testAbsolutePathFromString() {
-        let path = BIP32Path("m/0'/0") // 0' and 0h are treated the same
-        XCTAssertNotNil(path)
-        XCTAssertEqual(path!.components, [.hardened(0), .normal(0)])
-        XCTAssertEqual(path!.description, "m/0h/0") // description always uses h instead of '
-    }
-    
-    func testRelativePathFromInt() {
-        var path: BIP32Path
-        XCTAssertNoThrow(try BIP32Path(0))
-        path = try! BIP32Path(0)
-        XCTAssertEqual(path.components, [.normal(0)])
-        XCTAssertEqual(path.description, "0")
-        
-        XCTAssertThrowsError(try BIP32Path(Int(UINT32_MAX))) { error in
-            XCTAssertEqual(error as! BIP32Error, BIP32Error.invalidIndex)
-        }
-    }
-    
-    func testAbsolutePathFromInt() {
-        var path: BIP32Path
-        path = try! BIP32Path(0, relative: false)
-        XCTAssertEqual(path.description, "m/0")
-        
-        XCTAssertThrowsError(try BIP32Path(Int(UINT32_MAX))) { error in
-            XCTAssertEqual(error as! BIP32Error, BIP32Error.invalidIndex)
-        }
-    }
-    
     func testDerive() {
         let xpriv = "xprv9s21ZrQH143K3h3fDYiay8mocZ3afhfULfb5GX8kCBdno77K4HiA15Tg23wpbeF1pLfs1c5SPmYHrEpTuuRhxMwvKDwqdKiGJS9XFKzUsAF"
         let hdKey = HDKey(xpriv)!
         
-        let derivation = try! BIP32Path(0)
-        let childKey = try! hdKey.derive(derivation)
+        let childKey = try! hdKey.derive("0")
 
         XCTAssertNotNil(childKey.xpriv)
         XCTAssertEqual(childKey.xpriv!, "xprv9vEG8CuCbvqnJXhr1ZTHZYJcYqGMZ8dkphAUT2CDZsfqewNpq42oSiFgBXXYwDWAHXVbHew4uBfiHNAahRGJ8kUWwqwTGSXUb4wrbWz9eqo")
@@ -156,8 +119,7 @@ class BIP32Tests: XCTestCase {
         let xpriv = "xprv9s21ZrQH143K3h3fDYiay8mocZ3afhfULfb5GX8kCBdno77K4HiA15Tg23wpbeF1pLfs1c5SPmYHrEpTuuRhxMwvKDwqdKiGJS9XFKzUsAF"
         let hdKey = HDKey(xpriv)!
         
-        let derivation = try! BIP32Path(.hardened(0))
-        let childKey = try! hdKey.derive(derivation)
+        let childKey = try! hdKey.derive("0h")
 
         XCTAssertNotNil(childKey.xpriv)
         XCTAssertEqual(childKey.xpriv!, "xprv9vEG8CuLwbNkVNhb56dXckENNiU1SZEgwEAokv1yLodVwsHMRbAFyUMoMd5uyKEgPDgEPBwNfa42v5HYvCvT1ymQo1LQv9h5LtkBMvQD55b")
@@ -167,9 +129,7 @@ class BIP32Tests: XCTestCase {
         let xpriv = "xprv9s21ZrQH143K3h3fDYiay8mocZ3afhfULfb5GX8kCBdno77K4HiA15Tg23wpbeF1pLfs1c5SPmYHrEpTuuRhxMwvKDwqdKiGJS9XFKzUsAF"
         let hdKey = HDKey(xpriv)!
 
-        let path = BIP32Path("m/0'/0")!
-
-        let childKey = try! hdKey.derive(path)
+        let childKey = try! hdKey.derive("m/0'/0")
         
         XCTAssertNotNil(childKey.xpriv)
         XCTAssertEqual(childKey.xpriv!, "xprv9xcgxEx7PAbqP2YSijYjX38Vo6dV4i7g9ApmPRAkofDzQ6Hf4c3nBNRfW4EKSm2uhk4FBbjNFGjhZrATqLVKM2JjhsxSrUsDdJYK4UKhyQt")
@@ -179,16 +139,13 @@ class BIP32Tests: XCTestCase {
         let xpub = "xpub661MyMwAqRbcGB88KaFbLGiYAat55APKhtWg4uYMkXAmfuSTbq2QYsn9sKJCj1YqZPafsboef4h4YbXXhNhPwMbkHTpkf3zLhx7HvFw1NDy"
         let hdKey = HDKey(xpub)!
         
-        let path = BIP32Path("m/0")!
-        let childKey = try! hdKey.derive(path)
+        let childKey = try! hdKey.derive("m/0")
         
         XCTAssertNotNil(childKey.xpub)
         XCTAssertEqual(childKey.xpub, "xpub69DcXiS6SJQ5X1nK7azHvgFM6s6qxbMcBv65FQbq8DCpXjhyNbM3zWaA2p4L7Na2siUqFvyuK9W11J6GjqQhtPeJkeadtSpFcf6XLdKsZLZ")
         XCTAssertNil(childKey.xpriv)
         
-        let hardenedPath = BIP32Path("m/0'")!
-
-        XCTAssertThrowsError(try hdKey.derive(hardenedPath))
+        XCTAssertThrowsError(try hdKey.derive("m/0'"))
     }
 
     func testDeriveWithAbsolutePath() {
@@ -196,12 +153,10 @@ class BIP32Tests: XCTestCase {
         let xpub = "xpub6E64WfdQwBGz85XhbZryr9gUGUPBgoSu5WV6tJWpzAvgAmpVpdPHkT3XYm9R5J6MeWzvLQoz4q845taC9Q28XutbptxAmg7q8QPkjvTL4oi"
         let hdKey = HDKey(xpub)!
         
-        let relativePath = BIP32Path("0/0")!
-        let expectedChildKey = try! hdKey.derive(relativePath)
+        let expectedChildKey = try! hdKey.derive("0/0")
         
         // This should ignore the first 4 levels
-        let absolutePath = BIP32Path("m/48h/0h/0h/2h/0/0")!
-        let childKey = try! hdKey.derive(absolutePath)
+        let childKey = try! hdKey.derive("m/48h/0h/0h/2h/0/0")
         
         XCTAssertEqual(childKey.xpub, expectedChildKey.xpub)
     }

--- a/LibWallyTests/PSBTTests.swift
+++ b/LibWallyTests/PSBTTests.swift
@@ -26,12 +26,12 @@ class PSBTTests: XCTestCase {
     let masterKeyXpriv = "tprv8ZgxMBicQKsPd9TeAdPADNnSyH9SSUUbTVeFszDE23Ki6TBB5nCefAdHkK8Fm3qMQR6sHwA56zqRmKmxnHk37JkiFzvncDqoKmPWubu7hDF"
     
     // Paths
-    let path0 = BIP32Path("m/0'/0'/0'")!
-    let path1 = BIP32Path("m/0'/0'/1'")!
-    let path2 = BIP32Path("m/0'/0'/2'")!
-    let path3 = BIP32Path("m/0'/0'/3'")!
-    let path4 = BIP32Path("m/0'/0'/4'")!
-    let path5 = BIP32Path("m/0'/0'/5'")!
+    let path0 = "m/0'/0'/0'"
+    let path1 = "m/0'/0'/1'"
+    let path2 = "m/0'/0'/2'"
+    let path3 = "m/0'/0'/3'"
+    let path4 = "m/0'/0'/4'"
+    let path5 = "m/0'/0'/5'"
     
     // Private keys (testnet)
     let WIF_0 = "cP53pDbR5WtAD8dYAW9hhTjuvvTVaEiQBdrz9XPrgLBeRFiyCbQr" // m/0'/0'/0'

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Derive address from a seed:
 let mnemonic = BIP39Mnemonic("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about")
 let masterKey = HDKey(mnemonic.seedHex("bip39 passphrase"))!
 masterKey.fingerprint.hexString
-let path = BIP32Path("m/44'/0'/0'")!
+let path = "m/44'/0'/0'"
 let account = try! masterKey.derive(path)
 account.xpub
 account.address(.payToWitnessPubKeyHash)
@@ -54,7 +54,7 @@ Derive address from an xpub:
 
 ```swift
 let account = HDKey("xpub6ASuArnXKPbfEwhqN6e3mwBcDTgzisQN1wXN9BJcM47sSikHjJf3UFHKkNAWbWMiGj7Wf5uMash7SyYq527Hqck2AxYysAA7xmALppuCkwQ")
-let receivePath = BIP32Path("0/0")!
+let receivePath = "0/0"
 key = account.derive(receivePath)
 key.address(.payToPubKeyHash) # => 1JQheacLPdM5ySCkrZkV66G2ApAXe1mqLj
 ```
@@ -78,7 +78,7 @@ let input = TxInput(Transaction(txId)!, vout, amount, nil, witness, scriptPubKey
 transaction = Transaction([input], [TxOutput(destinationAddress.scriptPubKey, amount - 110)])
 transaction.feeRate // Satoshi per byte
 let accountPriv = HDKey("xpriv...")
-let privKey = try! accountPriv.derive(BIP32Path("0/0")!)
+let privKey = try! accountPriv.derive("0/0")
 transaction.sign([privKey])
 transaction.description # transaction hex
 ```


### PR DESCRIPTION
This gets rid of BIP32Path. Using `bip32_key_from_parent_path_str_alloc` introduced in https://github.com/ElementsProject/libwally-core/pull/309 (v0.8.5)

We now let libwally parse the path for derivation. The other way around is not yet available; we still have to reconstruct the path string from a `wally_ext_key`. See https://github.com/ElementsProject/libwally-core/issues/241

There's still some path string parsing logic in PSBT, which is where most of the changes are for this PR.

Another downside is that afaik libwally-core can't handle the case where you provide an absolute path (`m/x/y/z`) when deriving from e.g. level 2. So instead we convert the absolute path to a relative path first (`z`). See https://github.com/ElementsProject/libwally-core/issues/326

Fixes #65