### PR TITLE
Configure Github Actions to Build and Run Tests 

### DIFF
--- a/.github/actions/build-for-testing/action.yml
+++ b/.github/actions/build-for-testing/action.yml
@@ -1,0 +1,22 @@
+name: Build For Testing
+inputs:
+  scheme:
+    description: Scheme
+    required: true
+  destination:
+    description: Destination
+    required: true
+runs:
+  using: composite
+  steps:
+  - shell: bash
+    working-directory: .
+    run: |
+      xcodebuild clean build-for-testing \
+      -allowProvisioningUpdates \
+      -allowProvisioningDeviceRegistration \
+      -scheme '${{ inputs.scheme }}' \
+      -destination '${{ inputs.destination }}' \
+      -resultBundlePath BuildResults.xcresult
+
+      rm -rf AuthKey_${{ inputs.app-store-key-id }}.p8

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -1,0 +1,7 @@
+name: Install Dependencies
+runs:
+  using: composite
+  steps:
+  - shell: bash
+    run: |
+      brew install gnu-sed automake gcc autoconf libtool

--- a/.github/actions/test-without-building/action.yml
+++ b/.github/actions/test-without-building/action.yml
@@ -1,0 +1,36 @@
+name: Test Without Building
+inputs:
+  scheme:
+    description: Scheme
+    required: true
+  destination:
+    description: Destination
+    required: true
+  test-plan:
+    description: Test Plan
+    required: false
+  artifact-prefix:
+    description: The prefix for the filename of the uploaded xcresults file
+    required: true
+  check-name:
+    description: The check name
+    required: true
+runs:
+  using: composite
+  steps:
+  - shell: bash
+    id: vars
+    run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+  - shell: bash
+    working-directory: .
+    run: |
+      xcodebuild test-without-building \
+      -scheme '${{ inputs.scheme }}' \
+      -destination '${{ inputs.destination }}' \
+      -resultBundlePath "${{ inputs.artifact-prefix }}-${{ steps.vars.outputs.sha_short }}.xcresult"
+  - uses: kishikawakatsumi/xcresulttool@v1
+    if: always()
+    with:
+      path: ./${{ inputs.artifact-prefix }}-${{ steps.vars.outputs.sha_short }}.xcresult
+      title: ${{ inputs.check-name }}
+      show-passed-tests: false

--- a/.github/workflows/build-frameworks.yml
+++ b/.github/workflows/build-frameworks.yml
@@ -1,0 +1,67 @@
+name: Build Frameworks
+permissions:
+  contents: read
+  statuses: read
+  pull-requests: read
+  actions: read
+  checks: write
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - "*"
+jobs:
+  build:
+    name: Build (${{ matrix.configuration['platform'] }})
+    runs-on: macos-12
+    strategy:
+      fail-fast: false
+      matrix:
+        configuration:
+        - scheme: LibWally
+          destination: generic/platform=iOS
+          platform: iOS
+          sdk-name: iphoneos
+        - scheme: LibWally
+          destination: platform=iOS Simulator,OS=15.2,name=iPhone 13 Pro
+          platform: iOS Simulator
+          sdk-name: iphonesimulator
+          xcode-unit-test: LibWallyTests
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
+    steps:
+    - name: Configure Xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        fetch-depth: 0
+    - name: Install Dependencies
+      uses: ./.github/actions/install-dependencies
+    - name: Build
+      id: build
+      uses: ./.github/actions/build-for-testing
+      with:
+        scheme: ${{ matrix.configuration['scheme'] }}
+        destination: ${{ matrix.configuration['destination'] }}
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v3
+      if: ${{ always() }}
+      with:
+        name: config-log
+        path: CLibWally/libwally-core/config.log
+    - name: Xcode Unit Test
+      if: ${{ matrix.configuration['xcode-unit-test'] != '' }}
+      continue-on-error: true
+      uses: ./.github/actions/test-without-building
+      with:
+        scheme: ${{ matrix.configuration['scheme'] }}
+        destination: ${{ matrix.configuration['destination'] }}
+        test-plan: ${{ matrix.configuration['xcode-unit-test'] }}
+        artifact-prefix: unit-tests-${{ matrix.configuration['sdk-name'] }}
+        check-name: Xcode Unit Tests (${{ matrix.configuration['platform'] }})


### PR DESCRIPTION
Reopened of #71 (sorry!)

## Purpose
Set up workflows for CI with Github Actions. Addresses #63.

This is dependent on #69 which brings most of our build toolchain to be runnable directly from the Xcode project. 

## Implementation
Create a `build-frameworks` workflow which first builds the files and then runs tests.

You can see an example of the results here: https://github.com/jurvis/libwally-swift/actions/runs/2252283407

## Demo
<img width="1262" alt="image" src="https://user-images.githubusercontent.com/5944973/166133293-1f7c1587-6873-48eb-a053-107bddb22fc6.png">

## Next Steps
Write a workflow on release tag that will build an `xcframework` and upload a ZIP to GitHub.