### PR TITLE
Bump libwally-core to 0.8.6

### DIFF
--- a/CLibWally/module.modulemap
+++ b/CLibWally/module.modulemap
@@ -6,6 +6,7 @@ module CLibWally {
     header "libwally-core/include/wally_bip38.h"
     header "libwally-core/include/wally_bip39.h"
     header "libwally-core/include/wally_psbt.h"
+    header "libwally-core/include/wally_psbt_members.h"
     header "libwally-core/include/wally_script.h"
     header "libwally-core/include/wally_transaction.h"
     export *

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Opinionated Swift wrapper around [LibWally](https://github.com/ElementsProject/libwally-core),
 a collection of useful primitives for cryptocurrency wallets.
 
-Supports a minimal set of features based on v0.8.5. See also [original docs](https://wally.readthedocs.io/en/release_0.8.5).
+Supports a minimal set of features based on v0.8.6. See also [original docs](https://wally.readthedocs.io/en/release_0.8.6).
 
 - [ ] Core Functions
   - [x] base58 encode / decode


### PR DESCRIPTION
The secp256k1-zkp submodule at CLibWally/libwally-core/src/secp256k1 is updated along with libwally-core. In build-libwally.sh script we switch back to a vanilla  libwally at the same commit that Bitcoin Core uses.

Although Bitcoin Core bumped that commit a few months ago, we don't change it here because secp256k1-zkp has not yet been rebased on it.

There were two breaking change in libwally-core:

1. wally_psbt_from_bytes got an additional FLAGS argument in [0fb94751def8b2c767680e2428ebe2fdabd436c7](https://github.com/ElementsProject/libwally-core/pull/336/commits/0fb94751def8b2c767680e2428ebe2fdabd436c7) (ElementsProject/libwally-core#336): trivially fixed by setting it to 0

2. wally_psbt_output no longer has a witness_script field as of [8f8481a3c509fc4a02425db3839f92594e6ea852](https://github.com/ElementsProject/libwally-core/commit/8f8481a3c509fc4a02425db3839f92594e6ea852)  (ElementsProject/libwally-core#330). This required a more tedious workaround.